### PR TITLE
Add podcast page, powered by anchor RSS

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -17,6 +17,13 @@ module.exports = {
         path: `${__dirname}/src/images`,
       },
     },
+    // source podcast episodes from anchor.fm
+    {
+      resolve: 'gatsby-source-anchor',
+      options: {
+        rss: 'https://anchor.fm/s/2a4c840/podcast/rss',
+      },
+    },
     // source mdx for content
     {
       resolve: 'gatsby-source-filesystem',

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "gatsby-remark-embed-video": "^1.7.1",
     "gatsby-remark-images": "^3.0.14",
     "gatsby-remark-prismjs": "^3.2.11",
+    "gatsby-source-anchor": "^0.5.1",
     "gatsby-source-filesystem": "^2.0.38",
     "gatsby-source-shopify": "^2.0.37",
     "gatsby-transformer-remark": "^2.3.12",

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -24,6 +24,9 @@ const Header = ({ siteTitle }) => (
               <Link to="/blog" className={classes.link}>
                 Blog
               </Link>
+              <Link to="/podcast" className={classes.link}>
+                Podcast
+              </Link>
               <Link to="/videos" className={classes.link}>
                 Videos
               </Link>

--- a/src/pages/podcast/Podcast.module.css
+++ b/src/pages/podcast/Podcast.module.css
@@ -1,0 +1,52 @@
+.container {
+  margin-top: 3rem;
+}
+
+.episodeContainer {
+  padding: 0 0 5rem 0;
+  display: flex;
+  flex-direction: row;
+}
+
+.imageContainer {
+  height: 150px;
+  width: 150px;
+  margin-right: 2rem;
+}
+
+.date {
+  color: var(--gray);
+}
+
+.duration {
+  color: var(--purple);
+  margin-left: 10px;
+}
+
+.meta {
+  display: inline-block;
+  width: 100%;
+  padding-bottom: 0.5rem;
+}
+
+.titleLink {
+  display: flex;
+  align-items: center;
+}
+
+.title {
+  display: inline-block;
+  margin: 0;
+  padding: 0;
+}
+
+a .episode {
+  display: inline-block;
+  font-family: var(--serif-font-family);
+  font-weight: bold;
+  background-color: rgba(var(--black_rgb), var(--alpha-dimmed));
+  color: white;
+  height: 1.75rem;
+  padding: 0.15rem 0.5rem;
+  margin-right: 1rem;
+}

--- a/src/pages/podcast/index.js
+++ b/src/pages/podcast/index.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import { graphql } from 'gatsby';
+import { OutboundLink } from 'gatsby-plugin-google-analytics';
+import { Container, Col, Row } from 'react-bootstrap';
+import moment from 'moment';
+
+import { Layout } from '../../components';
+import classes from './Podcast.module.css';
+
+const PodcastPage = ({ data }) => {
+  const { podcasts } = data;
+
+  return (
+    <Layout>
+      <Container className={classes.container}>
+        <Row>
+          <Col>
+            <h1>Check out the podcast</h1>
+          </Col>
+        </Row>
+        {podcasts.nodes.map(podcast => (
+          <Row>
+            <Col>
+              <div className={classes.episodeContainer}>
+                <OutboundLink
+                  href={podcast.link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    className={classes.imageContainer}
+                    src={podcast.itunes.image}
+                    alt="APIs You Won\'t Hate cover"
+                  />
+                </OutboundLink>
+                <div>
+                  <OutboundLink
+                    href={podcast.link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={classes.titleLink}
+                  >
+                    <span className={classes.episode}>
+                      s{podcast.itunes.season} e{podcast.itunes.episode}{' '}
+                    </span>
+                    <h2 className={classes.title}>{podcast.title}</h2>
+                  </OutboundLink>
+                  <div className={classes.meta}>
+                    <span className={classes.date}>
+                      {moment(podcast.isoDate).calendar()}
+                    </span>
+                    <span className={classes.duration}>
+                      {moment.duration(podcast.itunes.duration * 1000).hours()}:
+                      {moment
+                        .duration(podcast.itunes.duration * 1000)
+                        .minutes()}
+                    </span>
+                  </div>
+                  <div dangerouslySetInnerHTML={{ __html: podcast.content }} />
+                </div>
+              </div>
+            </Col>
+          </Row>
+        ))}
+      </Container>
+    </Layout>
+  );
+};
+
+export const query = graphql`
+  {
+    podcasts: allAnchorEpisode {
+      nodes {
+        id
+        title
+        pubDate
+        link
+        content
+        contentSnippet
+        isoDate
+        itunes {
+          image
+          episode
+          season
+          duration
+        }
+      }
+    }
+  }
+`;
+
+export default PodcastPage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5894,6 +5894,13 @@ gatsby-remark-prismjs@^3.2.11:
     parse-numeric-range "^0.0.2"
     unist-util-visit "^1.3.0"
 
+gatsby-source-anchor@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/gatsby-source-anchor/-/gatsby-source-anchor-0.5.1.tgz#3df84f2e3b8dde8c5adeaf1df92224ba383cb824"
+  integrity sha512-qlbdyuJo2W6IXIHoqTGHh/+KjxyQBb89K1JaKlNPbNfkWZBDLNWBcXMtM/ndyscBDlZpwrbro5bpg+oyC3H0Rg==
+  dependencies:
+    rss-parser "^3.5.3"
+
 gatsby-source-filesystem@^2.0.38, gatsby-source-filesystem@^2.0.39:
   version "2.0.39"
   resolved "https://registry.yarnpkg.com/gatsby-source-filesystem/-/gatsby-source-filesystem-2.0.39.tgz#39d0f55aae594eea65454728676d92f1b43ba6e5"
@@ -11629,6 +11636,14 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
+rss-parser@^3.5.3:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/rss-parser/-/rss-parser-3.7.1.tgz#86d15d1c84b860d1aff1c00a2149278a9fe64c0b"
+  integrity sha512-1JKFzLHeteNandmlVBUWgLPmipFEllhdUQlmNvkXd6ju4VFOlGr0VmtlQaxzZoVysG2nbGb8eAtzNqQTxzQ+AQ==
+  dependencies:
+    entities "^1.1.1"
+    xml2js "^0.4.19"
+
 rss@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/rss/-/rss-1.2.2.tgz#50a1698876138133a74f9a05d2bdc8db8d27a921"
@@ -14112,7 +14127,7 @@ xml-parse-from-string@^1.0.0:
   resolved "https://registry.yarnpkg.com/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz#a9029e929d3dbcded169f3c6e28238d95a5d5a28"
   integrity sha1-qQKekp09vN7RafPG4oI42VpdWig=
 
-xml2js@^0.4.5:
+xml2js@^0.4.19, xml2js@^0.4.5:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
   integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==


### PR DESCRIPTION
Fixes #70 

This'll be easier once we have an episode published to anchor - I've used my own podcast's feed for the time being.  How's this look?

![image](https://user-images.githubusercontent.com/1844496/59897706-a59f6480-9389-11e9-938b-0067a02914fe.png)

# what it is
- adds a new link in header to `/podcast`
- sources podcast episode metadata from anchor.fm via a gatsby plugin
- each episode is displayed in reverse-chronological order on `/podcast`
- there is currently no page for an individual episode (we should use Anchor for that, I think?)


# todo:
- need to update the rss URL in `gatsby-config.js` to point to our podcast's feed