### PR TITLE
Update link to ajv on npm

### DIFF
--- a/src/content/blog/json-schema-client-side-validation.mdx
+++ b/src/content/blog/json-schema-client-side-validation.mdx
@@ -188,7 +188,7 @@ _Learn about [HTTP caching for clients](https://blog.apisyouwonthate.com/speedin
 
 Triggering validation rules on a random website is one thing, but learning how
 to do that with code is going to be far more useful. For JavaScript a module
-called [ajv](https://github.com/korzio/ajv) is fairly popular, so install that
+called [ajv](https://www.npmjs.com/package/ajv) is fairly popular, so install that
 with a simple `yarn add ajv@6`, then shove it in a JavaScript file. This code is
 available on [the new books GitHub
 Repo](http://apisyouwonthate/talking-to-other-peoples-apis-code).


### PR DESCRIPTION
The link to AJV in this post is pointing to what appears to be an older repo for ajv.  It looks like ownership changed hands to [this repo](https://github.com/epoberezkin/ajv) at some point, and will be moving to an org account sometime in the future:

<img width="772" alt="Pasted_Image_6_30_19__2_07_PM" src="https://user-images.githubusercontent.com/1844496/60400336-6c60b480-9b40-11e9-8746-9aa3d914869d.png">

Since we know there's another change coming, and npm should stay up to date with whomever owns the package being deployed by `npm install` or `yarn add`, I think it's safest to point our link to npm.