### PR TITLE
FFS make it all more reponsive already

### DIFF
--- a/src/components/BlogPostItem/BlogPostItem.js
+++ b/src/components/BlogPostItem/BlogPostItem.js
@@ -13,25 +13,27 @@ import classes from './BlogPostItem.module.css';
 const BlogPostItem = ({ post, feature = false }) => {
   const { author, date, coverImage, subtitle, title } = post.frontmatter;
   return (
-    <Link to={`/blog/${slugify(title)}`} className={classes.container}>
-      <Row>
-        <Col sm={12} xs={12} md={12} lg={feature ? 8 : 12}>
-          <CoverImage
-            src={coverImage}
-            className={
-              feature ? classes.featureImageContainer : classes.imageContainer
-            }
-          />
-        </Col>
-        <Col>
-          <main>
-            <h2 className={classes.title}>{title}</h2>
-            <p className={classes.subtitle}>{subtitle}</p>
-            <AuthorDisplay name={author} date={date} />
-          </main>
-        </Col>
-      </Row>
-    </Link>
+    <Col xs={12} sm={12} md={feature ? 12 : 6} lg={feature ? 12 : 4}>
+      <Link to={`/blog/${slugify(title)}`} className={classes.container}>
+        <Row>
+          <Col xs={12} sm={12} md={12} lg={feature ? 8 : 12}>
+            <CoverImage
+              src={coverImage}
+              className={
+                feature ? classes.featureImageContainer : classes.imageContainer
+              }
+            />
+          </Col>
+          <Col>
+            <main x>
+              <h2 className={classes.title}>{title}</h2>
+              <p className={classes.subtitle}>{subtitle}</p>
+              <AuthorDisplay name={author} date={date} />
+            </main>
+          </Col>
+        </Row>
+      </Link>
+    </Col>
   );
 };
 

--- a/src/components/BlogPostItem/BlogPostItem.module.css
+++ b/src/components/BlogPostItem/BlogPostItem.module.css
@@ -1,5 +1,7 @@
 .container {
+  display: block;
   cursor: pointer;
+  margin-bottom: 2rem;
 }
 .title {
   font-size: 1.5rem;

--- a/src/components/Footer/Footer.module.css
+++ b/src/components/Footer/Footer.module.css
@@ -1,5 +1,6 @@
 .footer {
-  padding: 3rem 3rem;
+  padding-top: 3rem;
+  padding-bottom: 3rem;
   border-top: 2px solid var(--gray);
 }
 

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -10,14 +10,14 @@ import classes from './Header.module.css';
 
 const Header = ({ siteTitle }) => (
   <div className={classes.background}>
-    <Container>
+    <Container className={classes.container}>
       <Row>
         <Col>
-          <header>
+          <header className={classes.header}>
             <h1 className={classes.title}>
               <Link to="/">{`APIs You Won't Hate`}</Link>
             </h1>
-            <nav>
+            <nav className={classes.navbar}>
               <Link to="/books" className={classes.link}>
                 Books
               </Link>

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -2,13 +2,6 @@
   background-color: var(--hateful-green);
 }
 
-/* get rid of container gutters on smaller viewports */
-@media (max-width: 998px) {
-  .container {
-    max-width: 100%;
-  }
-}
-
 .header {
   /* max-width: var(--site-width); */
   margin: 0 auto;

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -2,17 +2,31 @@
   background-color: var(--hateful-green);
 }
 
-header {
+/* get rid of container gutters on smaller viewports */
+@media (max-width: 998px) {
+  .container {
+    max-width: 100%;
+  }
+}
+
+.header {
   /* max-width: var(--site-width); */
   margin: 0 auto;
   padding: 1rem 0 1rem 0;
+}
+
+.navbar {
+  max-width: 100vw;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
 }
 
 .title {
   margin: 0 0 1rem 0;
   padding: 0;
   font-weight: 400;
-  font-size: 3.8rem;
+  font-size: 5vh;
   line-height: 1.2em;
   letter-spacing: 0.05rem;
 }

--- a/src/pages/blog/BlogPage.module.css
+++ b/src/pages/blog/BlogPage.module.css
@@ -1,22 +1,11 @@
 .container {
-  margin-top: 4rem;
+  margin-top: 2rem;
   margin-bottom: 4rem;
 }
 
-.postsContainer {
-  display: grid;
-  column-count: 3;
-  column-gap: 1.5rem;
-  row-gap: 1.5rem;
-  grid-template-columns: 1fr 1fr 1fr;
-}
-
-.article:first-of-type {
-  grid-column: span 3;
-}
-
-@media screen and (max-width: 100px) {
-  .article {
-    grid-column: span 3;
+/* get rid of container gutters on smaller viewports */
+@media (max-width: 998px) {
+  .container {
+    max-width: 100%;
   }
 }

--- a/src/pages/blog/BlogPage.module.css
+++ b/src/pages/blog/BlogPage.module.css
@@ -2,10 +2,3 @@
   margin-top: 2rem;
   margin-bottom: 4rem;
 }
-
-/* get rid of container gutters on smaller viewports */
-@media (max-width: 998px) {
-  .container {
-    max-width: 100%;
-  }
-}

--- a/src/pages/blog/index.js
+++ b/src/pages/blog/index.js
@@ -19,17 +19,9 @@ const BlogPage = ({ data }) => {
       <SEO title="Blog" />
       <Container className={classes.container}>
         <Row>
-          <Col>
-            <div className={classes.postsContainer}>
-              {posts.map((post, idx) => {
-                return (
-                  <article key={post.id} className={classes.article}>
-                    <BlogPostItem post={post} feature={idx === 0} />
-                  </article>
-                );
-              })}
-            </div>
-          </Col>
+          {posts.map((post, idx) => (
+            <BlogPostItem key={post.id} post={post} feature={idx === 0} />
+          ))}
         </Row>
       </Container>
     </Layout>
@@ -44,6 +36,7 @@ export const query = graphql`
       nodes {
         id
         body
+        excerpt
         frontmatter {
           coverImage
           date

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -119,7 +119,7 @@ const IndexPage = ({ data }) => {
             </p>
           </div>
         </Col>
-        <Col md className="d-lg-block d-xs-none d-sm-none d-md-none">
+        <Col lg className="d-lg-block d-xs-none d-sm-none d-md-none">
           <CoverImage
             src="about-phil.jpg"
             alt="Phil speaking at a conference"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -68,6 +68,12 @@ const IndexPage = ({ data }) => {
       </div>
 
       <Row noGutters className="align-items-stretch">
+        <Col xs={12} className="d-block d-sm-block d-md-block d-lg-none">
+          <CoverImage
+            src="about-phil.jpg"
+            alt="Phil speaking at a conference"
+          />
+        </Col>
         <Col>
           <div className={classes.aboutTeam}>
             <h2>About Phil Sturgeon</h2>
@@ -113,7 +119,7 @@ const IndexPage = ({ data }) => {
             </p>
           </div>
         </Col>
-        <Col>
+        <Col md className="d-lg-block d-xs-none d-sm-none d-md-none">
           <CoverImage
             src="about-phil.jpg"
             alt="Phil speaking at a conference"

--- a/src/pages/podcast/index.js
+++ b/src/pages/podcast/index.js
@@ -19,7 +19,7 @@ const PodcastPage = ({ data }) => {
           </Col>
         </Row>
         {podcasts.nodes.map(podcast => (
-          <Row>
+          <Row key={podcast.id}>
             <Col>
               <div className={classes.episodeContainer}>
                 <OutboundLink

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -131,6 +131,6 @@ table {
 /* get rid of container gutters on smaller viewports */
 @media (max-width: 998px) {
   .container {
-    max-width: 100%;
+    max-width: 100% !important;
   }
 }

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -127,3 +127,10 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
 }
+
+/* get rid of container gutters on smaller viewports */
+@media (max-width: 998px) {
+  .container {
+    max-width: 100%;
+  }
+}

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -130,7 +130,7 @@ table {
 
 /* get rid of container gutters on smaller viewports */
 @media (max-width: 998px) {
-  .container {
-    max-width: 100% !important;
+  div.container {
+    max-width: 100%;
   }
 }

--- a/src/templates/blog/Post.module.css
+++ b/src/templates/blog/Post.module.css
@@ -3,6 +3,14 @@
   padding: 0;
 }
 
+.coverImage {
+  max-height: 60vh;
+}
+
+.coverImage * img {
+  object-position: top center !important;
+}
+
 .post {
   margin-top: 3rem;
   font-family: var(--post-serif-font-family);


### PR DESCRIPTION
Related to #49 

Hey gang - if you have a chance, there's some responsive changes afoot here:

# Changes
- the home page should look nicer on smaller screens.  The navbar was causing mobile views to go wider than screen widths
- the blog page `/blog` should also be much better - as the viewport shrinks, posts will go from 3 wide to 2 wide to 1 wide
- individual blog posts got a dipslay tweak - I limited the height of the cover image to 70% of the screen width.  This is a little funky depending on the aspect ratio of the device you're viewing from, but at least now none of the article is stuffed "below the fold".  I'd still like to make this much better.
- it's a bit tricky to explain, but I got rid of the left- and right-hand gutters on all layouts for viewports smaller than `999px`.  This will give us the whole screen to work with in these views
- footer and nav padding were tweaked to look better on smaller views

# screenshots:

home:
![image](https://user-images.githubusercontent.com/1844496/63205510-40a77880-c073-11e9-94a0-992971b7e93d.png)


blog index:
1-wide-
![image](https://user-images.githubusercontent.com/1844496/63205512-4bfaa400-c073-11e9-9d6d-2773399d1e8b.png)

2-wide-
![image](https://user-images.githubusercontent.com/1844496/63205514-5ae15680-c073-11e9-88b4-dc97bfde4e17.png)

3-wide-
![image](https://user-images.githubusercontent.com/1844496/63205516-62a0fb00-c073-11e9-967d-ac6fc11cb338.png)