### PR TITLE
Add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# APIs You Won't Hate Community and Contributor Covenant Code of Conduct
+
+Our Code of Conduct page is available on the [APIs You Won't Hate](https://apisyouwonthate.com/conduct) website.

--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@
    Values from this file will be injected into the react runtime following [these rules](https://www.gatsbyjs.org/docs/environment-variables/) whenever you start the project with `gatsby develop` (or `yarn start` / `npm run start`, which just runs `gatsby develop`). (**Note**: any additional environment variables _must_ start with `GATSBY_`)
 
 1. `yarn start` will run the local dev environment 👍
+
+## Code of Conduct
+
+Our aim is to build a constructive, inclusive, and positive community. Please give our our [Code of Conduct](./CODE_OF_CONDUCT.md) a read through before contributing.

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,5 +1,4 @@
 const slugify = require('./src/utils/slugify');
-const { size } = require('lodash');
 
 module.exports = {
   siteMetadata: {

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -30,6 +30,9 @@ const Footer = () => (
             <li>
               <Link to="/community">Community</Link>
             </li>
+            <li>
+              <Link to="/conduct">Code of Conduct</Link>
+            </li>
           </ul>
         </Col>
         <Col lg={3}>

--- a/src/pages/ama/index.js
+++ b/src/pages/ama/index.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { graphql, Link } from 'gatsby';
 import { Button, Container, Col, Form, Row } from 'react-bootstrap';
+import Helmet from 'react-helmet';
 
 import { Layout } from '../../components';
 import classes from './AMA.module.css';
@@ -34,6 +35,7 @@ const AMAPage = () => {
 
   return (
     <Layout>
+      <Helmet title="Ask us a question!" />
       <Container className={classes.container}>
         {submitted ? (
           <>

--- a/src/pages/conduct/Conduct.module.css
+++ b/src/pages/conduct/Conduct.module.css
@@ -1,0 +1,8 @@
+.coc {
+  max-width: 70ch;
+}
+
+.coc ul {
+  list-style: disc;
+  list-style-position: inside;
+}

--- a/src/pages/conduct/index.js
+++ b/src/pages/conduct/index.js
@@ -1,0 +1,160 @@
+import React from 'react';
+import { OutboundLink } from 'gatsby-plugin-google-analytics';
+import { Container, Col, Row } from 'react-bootstrap';
+import Helmet from 'react-helmet';
+
+import { Layout } from '../../components';
+import classes from './Conduct.module.css';
+
+const ConductPage = () => (
+  <Layout>
+    <Helmet title="Contributor Covenant Code of Conduct" />
+
+    <Container className={classes.container}>
+      <Row>
+        <Col>
+          <h1 id="contributor-covenant-code-of-conduct">
+            Contributor Covenant Code of Conduct
+          </h1>
+        </Col>
+      </Row>
+      <br />
+      <br />
+      <Row>
+        <Col>
+          <section className={classes.coc}>
+            <h2 id="our-pledge">Our Pledge</h2>
+
+            <p>
+              {
+                'In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.'
+              }
+            </p>
+
+            <h2 id="our-standards">Our Standards</h2>
+
+            <p>
+              {
+                'Examples of behavior that contributes to creating a positive environment include:'
+              }
+            </p>
+
+            <ul>
+              <li>Using welcoming and inclusive language</li>
+              <li>Being respectful of differing viewpoints and experiences</li>
+              <li>Gracefully accepting constructive criticism</li>
+              <li>Focusing on what is best for the community</li>
+              <li>Showing empathy towards other community members</li>
+            </ul>
+
+            <p>Examples of unacceptable behavior by participants include:</p>
+
+            <ul>
+              <li>
+                {
+                  'The use of sexualized language or imagery and unwelcome sexual attention or advances'
+                }
+              </li>
+              <li>
+                {
+                  'Trolling, insulting/derogatory comments, and personal or political attacks '
+                }
+              </li>
+              <li>Public or private harassment</li>
+              <li>
+                {
+                  'Publishing others’ private information, such as a physical or electronic address, without explicit permission '
+                }
+              </li>
+              <li>
+                {
+                  'Other conduct which could reasonably be considered inappropriate in a professional setting'
+                }
+              </li>
+            </ul>
+
+            <h2 id="our-responsibilities">Our Responsibilities</h2>
+
+            <p>
+              {
+                'Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.'
+              }
+            </p>
+
+            <p>
+              {
+                'Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.'
+              }
+            </p>
+
+            <h2 id="scope">Scope</h2>
+
+            <p>
+              {
+                'This Code of Conduct applies within all project spaces, and it also applies when an individual is representing the project or its community in public spaces. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.'
+              }
+            </p>
+
+            <h2 id="enforcement">Enforcement</h2>
+
+            <p>
+              {
+                'Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at '
+              }
+              <a href="mailto:phil+coc@apisyouwonthate.com">
+                phil+coc@apisyouwonthate.com
+              </a>
+              {
+                '. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.'
+              }
+            </p>
+
+            <p>
+              {
+                'Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project’s leadership.'
+              }
+            </p>
+
+            <h2 id="attribution">Attribution</h2>
+
+            <p>
+              This Code of Conduct is adapted from the{' '}
+              <OutboundLink
+                href="https://www.contributor-covenant.org"
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                Contributor Covenant
+              </OutboundLink>
+              , version 1.4, available at{' '}
+              <OutboundLink
+                href="https://www.contributor-covenant.org/version/1/4/code-of-conduct"
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+              </OutboundLink>
+              .
+            </p>
+
+            <p>
+              {
+                'For answers to common questions about this code of conduct, see '
+              }
+              <OutboundLink
+                href="https://www.contributor-covenant.org/faq"
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                https://www.contributor-covenant.org/faq
+              </OutboundLink>
+              .
+            </p>
+          </section>
+        </Col>
+      </Row>
+    </Container>
+  </Layout>
+);
+
+export default ConductPage;


### PR DESCRIPTION
Fixes #293. 

# CoC related
- Adds a code of conduct page at `/conduct`
- Adds a link to that page in the site footer
- adds `CODE_OF_CONDUCT.md` to this repo, pointing to the code of conduct on the web site

# misc
- removes an unused import in gatsby-config
- adds a <title> tag to the `/ama` page

# questions
- [ ] Right now this includes a pointer to `phil+coc@apisyouwonthate.com` for code of conduct reports.  If that's cool, feel free to merge, otherwise I'm happy to change it