### PR TITLE
Loosen up dependabot's settings

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,9 +1,15 @@
 version: 1
 
 update_configs:
-  - package_manager: "javascript"
-    directory: "/"
-    update_schedule: "live"
+  - package_manager: 'javascript'
+    directory: '/'
+    update_schedule: 'weekly'
+    allowed_updates:
+      - match:
+          dependency_type: 'direct'
+      - match:
+          dependency_type: 'production'
+          update_type: 'security'
     automerged_updates:
       - match:
-          update_type: "semver:minor"
+          update_type: 'semver:minor'


### PR DESCRIPTION
We're still overrunning netlify's build minutes by quite a bit - I'm hoping this will loosen that noose a bit.

Config file docs are [here](https://dependabot.com/docs/config-file/) if you'd like to check the changes I made.