### PR TITLE
changed the hover color on footer #538

### DIFF
--- a/src/components/Footer/Footer.module.css
+++ b/src/components/Footer/Footer.module.css
@@ -11,7 +11,7 @@
 }
 
 .footer a:hover {
-  color: var(--purple);
+  filter: brightness(75%)
 }
 
 .linkList li {


### PR DESCRIPTION
Footer links become invisible on hover
Issue #538 



I change the hover color to a brightness filter instead of the purple that made links disappear.
It's more consistent with how other hovers on the site look. 
I chose a brightness filter because I also didn't want to add another color to the project.


https://user-images.githubusercontent.com/51421669/117189998-da193f80-adac-11eb-9e34-62c8f52d77b6.mov

