### PR TITLE
Fix links and add attribution to old post

### DIFF
--- a/src/content/blog/common-hypermedia-patterns-with-json-hyper-schema.mdx
+++ b/src/content/blog/common-hypermedia-patterns-with-json-hyper-schema.mdx
@@ -7,7 +7,9 @@ type: blog
 author: Phil Sturgeon
 ---
 
-In the last two JSON-Hyper Schema articles (Getting Started — Part One and Part Two), we covered the basics:
+_Guest post from [Aaron Hedges](https://twitter.com/Dashron)._
+
+In the last two JSON-Hyper Schema articles (Getting Started — [Part One](/blog/getting-started-with-json-hyper-schema) and [Part Two](/blog/getting-started-with-json-hyper-schema-part-2)), we covered the basics:
 
 * Basic Links
 * Request and response bodies


### PR DESCRIPTION
I had forgotten about this until someone mentioned it this morning. Fixed some links and added my attribution back to the final json hyperschema article.