### PR TITLE
Bug/remove remotive jobs in sitemap

### DIFF
--- a/next-sitemap.js
+++ b/next-sitemap.js
@@ -3,5 +3,21 @@ const config = require('./config');
 module.exports = {
   siteUrl: process.env.SITE_URL || config.siteMetadata.siteUrl,
   generateRobotsTxt: process.env.CONTEXT === 'production', // only generate robots.txt for prod
+
+  transform: async (config, path) => {
+    // trying to remove all remotive jobs from sitemap - they will start with `/jobs/` and end with a dash and a number `-123456`
+    const remotiveJobsRegEx = /^\/jobs\/.*-\d*$/gm;
+    if (remotiveJobsRegEx.test(path)) return null;
+
+    console.log('path', path);
+    return {
+      loc: path, // => this will be exported as http(s)://<config.siteUrl>/<path>
+      changefreq: config.changefreq,
+      priority: config.priority,
+      lastmod: config.autoLastmod ? new Date().toISOString() : undefined,
+      alternateRefs: config.alternateRefs ?? [],
+    };
+  },
+
   // ...other options
 };

--- a/src/content/blog/govern-your-apis-with-speccy.mdx
+++ b/src/content/blog/govern-your-apis-with-speccy.mdx
@@ -78,5 +78,5 @@ multiple products of a recent hackathon. I’ll get it cleaned up and out on
 speccy.io at some point. As far as a rules marketplace goes, that’s a while off.
 For now, how about you folks get in the comments,
 [Twitter](https://twitter.com/apisyouwonthate/), or
-[Slack,](http://slack.apisyouwonthate.com) with suggestions for rules that you’d
+[Slack,](https://slack.apisyouwonthate.com) with suggestions for rules that you’d
 like to see.

--- a/src/content/blog/json-api-openapi-and-json-schema.mdx
+++ b/src/content/blog/json-api-openapi-and-json-schema.mdx
@@ -10,7 +10,7 @@ author: Phil Sturgeon
 ---
 
 A regular question on Twitter, at WeWork, and in the [APIs You Won’t Hate Slack
-community,](http://slack.apisyouwonthate.com/) is: “What standard should my API
+community,](https://slack.apisyouwonthate.com/) is: “What standard should my API
 follow? Should it be JSON API or something else?” At which point a bunch of
 people usually start discussing things like OpenAPI and/or JSON Schema. In this
 article, I’d like to talk about how they can all work together in harmony, to do

--- a/src/content/blog/why-some-people-dislike-json.mdx
+++ b/src/content/blog/why-some-people-dislike-json.mdx
@@ -77,7 +77,7 @@ book](https://apisyouwonthate.com/books/build-apis-you-wont-hate.html).
 Confusing REST for this oversimplified style of interaction, then blaming it for
 tripping you up, is exceedingly daft.
 
-![](src/images/posts/rest-baton.jpeg)
+![devs be like](/images/posts/rest-baton.jpeg)
 
 #### Everything Will Happen Again
 

--- a/src/pages/community/index.js
+++ b/src/pages/community/index.js
@@ -29,7 +29,7 @@ const CommunityPage = () => (
           <Button
             colorScheme="purple"
             as="a"
-            href="http://slack.apisyouwonthate.com"
+            href="https://slack.apisyouwonthate.com"
             target="_blank"
             rel="noreferrer noopener"
           >


### PR DESCRIPTION
This is an SEO fix - it's bad practice to put things in our sitemap which have canonical links pointing to another domain